### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ source 'https://rubygems.org'
 # Please keep in sync with the one in .travis.yml and .ruby-version.
 ruby '2.6.3'
 
+gem 'buckygem',
+    git: 'https://github.com/dirtyhenry/buckygem.git',
+    branch: 'master'
 gem 'html-proofer'
 gem 'jekyll'
 gem 'kids',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,20 @@
 GIT
-  remote: https://github.com/dirtyhenry/kids.git
-  revision: 65d05a6f46617985761421224be65370693dcfee
+  remote: https://github.com/dirtyhenry/buckygem.git
+  revision: c4b2b76a4352aa032c8d3d0af1550f1fd6da813f
   branch: master
   specs:
-    kids (0.1.1)
+    buckygem (0.6.0)
+      i18n
+      liquid (~> 4.0)
+      mini_magick
+
+GIT
+  remote: https://github.com/dirtyhenry/kids.git
+  revision: 9267b64fe6bab036cf3abbd27e4e3fa988d4d4a5
+  branch: master
+  specs:
+    kids (0.2.0)
+      buckygem (~> 0.5)
       jekyll (>= 4.0, < 5.0)
       jekyll-assets
       jekyll-commonmark (~> 1.3)
@@ -12,7 +23,7 @@ GIT
 
 GIT
   remote: https://github.com/envygeeks/jekyll-assets
-  revision: 47fc845853e27af1877691efceba991f20f46526
+  revision: 056d2c88719ef3b1f90967a606dd1441581dd832
   branch: master
   specs:
     jekyll-assets (4.0.0.alpha)
@@ -31,20 +42,21 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.2.2)
+    activesupport (6.0.3.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    ast (2.4.0)
+    ast (2.4.1)
+    chef-utils (16.6.14)
     colorator (1.1.0)
     commonmarker (0.21.0)
       ruby-enum (~> 0.5)
-    concurrent-ruby (1.1.6)
-    em-websocket (0.5.1)
+    concurrent-ruby (1.1.7)
+    em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     ethon (0.12.0)
@@ -53,10 +65,10 @@ GEM
     execjs (2.7.0)
     extras (0.3.0)
       forwardable-extended (~> 2.5)
-    fastimage (2.1.7)
-    ffi (1.12.2)
+    fastimage (2.2.0)
+    ffi (1.13.1)
     forwardable-extended (2.6.0)
-    html-proofer (3.15.2)
+    html-proofer (3.16.0)
       addressable (~> 2.3)
       mercenary (~> 0.3)
       nokogumbo (~> 2.0)
@@ -65,20 +77,19 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
     http_parser.rb (0.6.0)
-    i18n (1.8.2)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.4)
-    jekyll (4.0.0)
+    jekyll (4.1.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
-      i18n (>= 0.9.5, < 2)
+      i18n (~> 1.0)
       jekyll-sass-converter (~> 2.0)
       jekyll-watch (~> 2.0)
       kramdown (~> 2.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (~> 0.3.3)
+      mercenary (~> 0.4.0)
       pathutil (~> 0.9)
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
@@ -86,7 +97,7 @@ GEM
     jekyll-commonmark (1.3.1)
       commonmarker (~> 0.14)
       jekyll (>= 3.7, < 5.0)
-    jekyll-feed (0.13.0)
+    jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-liquify (0.0.2)
       liquid (>= 2.5, < 5.0)
@@ -96,13 +107,14 @@ GEM
       pathutil (~> 0.16)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
-    jekyll-seo-tag (2.6.1)
-      jekyll (>= 3.3, < 5.0)
+    jekyll-seo-tag (2.7.1)
+      jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.1.0)
+    kramdown (2.3.0)
+      rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
@@ -112,68 +124,77 @@ GEM
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    mdl (0.9.0)
-      kramdown (~> 2.0)
-      kramdown-parser-gfm (~> 1.0)
+    mdl (0.11.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
       mixlib-cli (~> 2.1, >= 2.1.1)
       mixlib-config (>= 2.2.1, < 4)
-    mercenary (0.3.6)
+      mixlib-shellout
+    mercenary (0.4.0)
+    mini_magick (4.10.1)
     mini_portile2 (2.4.0)
-    minitest (5.14.0)
-    mixlib-cli (2.1.6)
-    mixlib-config (3.0.6)
+    minitest (5.14.2)
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.9)
       tomlrb
-    nokogiri (1.10.9)
+    mixlib-shellout (3.1.6)
+      chef-utils
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
-    parallel (1.19.1)
-    parser (2.7.1.0)
-      ast (~> 2.4.0)
+    parallel (1.19.2)
+    parser (2.7.2.0)
+      ast (~> 2.4.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (4.0.4)
-    rack (2.2.2)
+    public_suffix (4.0.6)
+    rack (2.2.3)
     rainbow (3.0.0)
-    rb-fsevent (0.10.3)
+    rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.0)
+    regexp_parser (1.8.2)
     rexml (3.2.4)
-    rouge (3.17.0)
-    rubocop (0.81.0)
-      jaro_winkler (~> 1.5.1)
+    rouge (3.24.0)
+    rubocop (1.0.0)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
       rexml
+      rubocop-ast (>= 0.6.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.0.0)
+      parser (>= 2.7.1.5)
     ruby-enum (0.8.0)
       i18n
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
-    sassc (2.2.1)
+    sassc (2.4.0)
       ffi (~> 1.9)
-    sprockets (4.0.0)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
     tomlrb (1.3.0)
-    typhoeus (1.3.1)
+    typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
     yell (2.2.2)
-    zeitwerk (2.3.0)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  buckygem!
   html-proofer
   jekyll
   jekyll-assets!

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ run:
 lint:
 	bundle exec rubocop
 	bundle exec mdl _posts/
-	htmlproofer --assume-extension --http-status-ignore "999" --check_img_http ./_site
+	bundle exec htmlproofer --assume-extension --http-status-ignore "999" --check_img_http ./_site

--- a/_sass/kids.scss
+++ b/_sass/kids.scss
@@ -1,11 +1,24 @@
 @charset "utf-8";
 
 // Define defaults for each variable.
+$background-color: #fff;
 $text-color: #333;
+
+$background-color-dark: #333;
+$text-color-dark: #fff;
+
+$text-color-subdued: #666;
+$text-color-subdued-dark: #aaa;
+
 $accent-color: #d64;
+$accent-color-dark: #e86;
+
 $accent-inverted: #fff;
+$accent-inverted-dark: #333;
+
 $accent-inverted-active: #ccc;
+$accent-inverted-active-dark: #666;
 
 // Import partials.
-@import "kids/base", "kids/images", "kids/layout", "kids/links",
-  "kids/typography";
+@import "kids/base", "kids/images", "kids/index", "kids/layout", "kids/links",
+  "kids/related_pages", "kids/typography";

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,31 @@
+---
+en:
+  common:
+    next: next
+    previous: previous
+  date:
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+      -
+      - January
+      - February
+      - March
+      - April
+      - May
+      - June
+      - July
+      - August
+      - September
+      - October
+      - November
+      - December
+    order:
+      - :year
+      - :month
+      - :day
+  time:
+    formats:
+      default_date: "%B %d, %Y"


### PR DESCRIPTION
This MR adds recent updates from the Kids plugin in, and also updates other Ruby dependencies.

Some `I18n` support was required.