### PR TITLE
Change permalink of 404 page to match GitHub pages docs reco

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: /404.html
 ---
 
 <style type="text/css" media="screen">


### PR DESCRIPTION
I got an e-mail from Google Search Console that the site had a soft 404. This PR is supposed to fix this according to https://docs.github.com/en/github/working-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site
and https://developers.google.com/search/docs/advanced/crawling/soft-404-errors